### PR TITLE
[Proposal] Rename commands to reflect the result

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -1,10 +1,10 @@
 {
-	"text-transformer.upper.title": "Upper Case",
-	"text-transformer.lower.title": "Lower Case",
-	"text-transformer.reverse.title": "Reverse Case",
-	"text-transformer.camel.title": "Camel Case",
-	"text-transformer.camel_space.title": "Upper Camel Case with Space",
-	"text-transformer.pascal.title": "Pascal Case",
-	"text-transformer.dashed.title": "Dashed Line",
-	"text-transformer.underline.title": "Underline"
+	"text-transformer.upper.title": "Text Transform > UPPERCASE",
+	"text-transformer.lower.title": "Text Transform > lowercase",
+	"text-transformer.reverse.title": "Text Transform > rEVERSE cASE",
+	"text-transformer.camel.title": "Text Transform > camelCase",
+	"text-transformer.camel_space.title": "Text Transform > Upper Camel Case With Space",
+	"text-transformer.pascal.title": "Text Transform > PascalCase",
+	"text-transformer.dashed.title": "Text Transform > kebab-case",
+	"text-transformer.underline.title": "Text Transform > snake_case"
 }


### PR DESCRIPTION
I suggest to update the commands names in English, because it's a bit confusing to find the right command.

* I added a common prefix so that we can filter by "Text Transform" to see all commands provided by the extension.
* I renamed `dashline` to `kebab-case` and `underline` to `snake_case` since it's the correct case name I expected.

Sadly it's not yet possible to have commands alias (i.e. having 2 different names for a same command) in VSCode. I wish we could have both `dashline` and `kebab-case`...

Let me know what you think!