### PR TITLE
Move contextual menu items into a group

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,55 +57,59 @@
                 "title": "%text-transformer.underline.title%"
             }
         ],
+        "submenus": [
+            {
+                "id": "text.transform",
+                "label": "Text Transform"
+            }
+        ],
         "menus": {
-            "editor/context": [
+            "text.transform": [
                 {
                     "when": "editorHasSelection",
                     "command": "text-transformer.upper",
-                    "alt": "text-transformer.upper",
-                    "group": "7_modification@1"
+                    "alt": "text-transformer.upper"
                 },
                 {
                     "when": "editorHasSelection",
                     "command": "text-transformer.lower",
-                    "alt": "text-transformer.lower",
-                    "group": "7_modification@2"
+                    "alt": "text-transformer.lower"
                 },
                 {
                     "when": "editorHasSelection",
                     "command": "text-transformer.reverse",
-                    "alt": "text-transformer.reverse",
-                    "group": "7_modification@3"
+                    "alt": "text-transformer.reverse"
                 },
                 {
                     "when": "editorHasSelection",
                     "command": "text-transformer.camel",
-                    "alt": "text-transformer.camel",
-                    "group": "7_modification@4"
+                    "alt": "text-transformer.camel"
                 },
                 {
                     "when": "editorHasSelection",
                     "command": "text-transformer.camel_space",
-                    "alt": "text-transformer.camel_space",
-                    "group": "7_modification@7"
+                    "alt": "text-transformer.camel_space"
                 },
                 {
                     "when": "editorHasSelection",
                     "command": "text-transformer.dashed",
-                    "alt": "text-transformer.dashed",
-                    "group": "7_modification@5"
+                    "alt": "text-transformer.dashed"
                 },
                 {
                     "when": "editorHasSelection",
                     "command": "text-transformer.underline",
-                    "alt": "text-transformer.underline",
-                    "group": "7_modification@6"
+                    "alt": "text-transformer.underline"
                 },
                 {
                     "when": "editorHasSelection",
                     "command": "text-transformer.pascal",
-                    "alt": "text-transformer.pascal",
-                    "group": "7_modification@8"
+                    "alt": "text-transformer.pascal"
+                }
+            ],
+            "editor/context": [
+                {
+                    "submenu": "text.transform",
+                    "group": "7_modification"
                 }
             ]
         },

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,10 +1,10 @@
 {
-    "text-transformer.upper.title": "Text Transform > UPPERCASE",
-    "text-transformer.lower.title": "Text Transform > lowercase",
-    "text-transformer.reverse.title": "Text Transform > rEVERSE cASE",
-    "text-transformer.camel.title": "Text Transform > camelCase",
-    "text-transformer.camel_space.title": "Text Transform > Upper Camel Case With Space",
-    "text-transformer.pascal.title": "Text Transform > PascalCase",
-    "text-transformer.dashed.title": "Text Transform > kebab-case",
-    "text-transformer.underline.title": "Text Transform > snake_case"
+    "text-transformer.upper.title": "UPPERCASE",
+    "text-transformer.lower.title": "lowercase",
+    "text-transformer.reverse.title": "rEVERSE cASE",
+    "text-transformer.camel.title": "camelCase",
+    "text-transformer.camel_space.title": "Upper Camel Case With Space",
+    "text-transformer.pascal.title": "PascalCase",
+    "text-transformer.dashed.title": "kebab-case",
+    "text-transformer.underline.title": "snake_case"
 }


### PR DESCRIPTION
To avoid clutering the contextual menu on the text editor (which is already quite big), I move all the text transform commands into a specific group with submenu.

Before: 
<img width="434" alt="text-transform-cmds-before" src="https://github.com/user-attachments/assets/caba3cd4-cf95-427e-94e6-ba99178411e1">
After:
<img width="626" alt="text-transform-cmds-after" src="https://github.com/user-attachments/assets/ac5fa4f7-043d-4961-94e5-d435fe230ab3">
